### PR TITLE
Removing extra border that is not necessary (plus looks weird on smaller screens)

### DIFF
--- a/static/css/page_view.css
+++ b/static/css/page_view.css
@@ -32,7 +32,7 @@
 }
 
 @media (max-width: 920px) {
-  
+
   .outerBackground{
     width:100%;
   }
@@ -42,7 +42,6 @@
   }
   #editorcontainer{
     top:0px;
-    border-top: 1px solid #ccc;
   }
 
 }


### PR DESCRIPTION
The removed `border-top` is responsible for a "double-border" between toolbar and editor on smaller screens:
![image](https://cloud.githubusercontent.com/assets/836386/8524807/b8f4e200-23d3-11e5-874a-d603b0f37d29.png)

As it does not look necessary, I've removed it. **Did I miss something**?

Here are the scenarios I've tested:

* large screen, regular editor:
![image](https://cloud.githubusercontent.com/assets/836386/8524967/997c95a2-23d4-11e5-97dc-50ba6f7d85d9.png)

* large screen, timeslider:
![image](https://cloud.githubusercontent.com/assets/836386/8524977/a4fae67c-23d4-11e5-83ee-5027f321323f.png)

* medium screen (when both left and right toolbars are on top of the page):
![image](https://cloud.githubusercontent.com/assets/836386/8524990/b532a1c4-23d4-11e5-9460-3e1e0d5838a5.png)

* small screen (when right toolbar is moved to the bottom of the page, which is the scenario where the original issue was):
![image](https://cloud.githubusercontent.com/assets/836386/8524999/c4401fca-23d4-11e5-957c-be000b67dc0f.png)

* Page View disabled on large screen:
![image](https://cloud.githubusercontent.com/assets/836386/8524934/6fd01d6e-23d4-11e5-9313-1079870a75dd.png)

I've also tested on FF, looked fine too.
