### PR TITLE
Display line numbers correctly when LNs are enabled but PV is not

### DIFF
--- a/static/js/page_view.js
+++ b/static/js/page_view.js
@@ -146,6 +146,16 @@ exports.postAceInit = function(hook, context){
       padcookie.setPref("page_breaks", false);
     }
   });
+  // line numbers
+  $('#options-linenoscheck').on('click', function() {
+    if($('#options-linenoscheck').is(':checked') && $('#options-pageview').is(':checked')) {
+      $outerIframeContents.find('#sidediv').addClass("lineNumbersAndPageView");
+      $innerdocbody.addClass('innerPVlineNumbers');
+    } else {
+      $outerIframeContents.find('#sidediv').removeClass("lineNumbersAndPageView");
+      $innerdocbody.removeClass('innerPVlineNumbers');
+    }
+  });
 
   // Bind the event handler to the toolbar buttons
   $('#insertPageBreak').on('click', function(){


### PR DESCRIPTION
If user changes the "Line numbers" setting but does not change the "Page
View" setting, the line number ruler needs to have its layout adjusted
(by adding some CSS classes), otherwise it will be displayed incorrectly
(not aligned with actual lines on pad.

![image](https://cloud.githubusercontent.com/assets/836386/12818580/9cc935d2-cb3e-11e5-8813-372f15a9a993.png)
